### PR TITLE
Allow portlets to receive the icon option

### DIFF
--- a/app/assets/stylesheets/pure_admin/portlets.css.scss
+++ b/app/assets/stylesheets/pure_admin/portlets.css.scss
@@ -70,8 +70,7 @@ $icon-minus: '\f068';
     .fa {
       border-right: 1px solid $grey-medium-dark;
       margin-right: 10px;
-      padding: 10px;
-      padding-left: 0;
+      padding: 0 1.5em 0 0;
       position: relative;
       top: 0;
     }

--- a/app/helpers/pure_admin/application_helper.rb
+++ b/app/helpers/pure_admin/application_helper.rb
@@ -35,6 +35,9 @@ module PureAdmin::ApplicationHelper
     inner = ''.html_safe
     unless title.blank?
       title_content = ''.html_safe
+      if options[:icon]
+        title = title.prepend(content_tag(:i, nil, class: "fa fa-fw fa-#{options[:icon]}")).html_safe
+      end
       title_content << content_tag(:h4, title)
 
       indicator = ''.html_safe

--- a/spec/helpers/pure_admin/application_helper_spec.rb
+++ b/spec/helpers/pure_admin/application_helper_spec.rb
@@ -68,6 +68,14 @@ describe PureAdmin::ApplicationHelper do
             it { is_expected.to_not have_selector('.portlet[data-expand=true]') }
           end
         end
+
+        context 'when an icon is given' do
+          subject(:html) { portlet('apples', icon: :pencil) { 'banana' } }
+
+          it 'contains the correct FontAwesome element' do
+            expect(html).to have_selector('.portlet-title h4 .fa.fa-fw.fa-pencil')
+          end
+        end
       end
 
       context 'when the source attribute is passed in' do
@@ -91,6 +99,14 @@ describe PureAdmin::ApplicationHelper do
           it { is_expected.to_not have_selector('.portlet[data-expand=true]') }
 
           it { is_expected.to have_selector('.portlet[data-source="google.com"]') }
+        end
+
+        context 'when an icon is given' do
+          subject(:html) { portlet('apples', source: 'google.com', icon: :pencil) }
+
+          it 'contains the correct FontAwesome element' do
+            expect(html).to have_selector('.portlet-title h4 .fa.fa-fw.fa-pencil')
+          end
         end
       end
     end


### PR DESCRIPTION
This PR allows devs to pass an icon option to the portlet, which generates a FontAwesome icon and prepends it to the title. It also fixes a portlet height display issue when icons are involved.

e.g.

```
<%= portlet 'Hamburger', icon: :bars do %>
```
