### PR TITLE
Add details panel helper

### DIFF
--- a/app/assets/stylesheets/pure_admin/details_panels.css.scss
+++ b/app/assets/stylesheets/pure_admin/details_panels.css.scss
@@ -6,7 +6,7 @@
   padding-bottom: $base-font-size;
   padding: 0 0.5em 1em 0.5em;
 
-  @media (min-width: 48em) {
+  @media (min-width: 35.5em) {
     padding: 0;
     padding-bottom: 1em;
   }
@@ -16,7 +16,7 @@
   margin: $base-font-size * 0.5 0;
   word-wrap: break-word;
 
-  @media (min-width: 48em) {
+  @media (min-width: 35.5em) {
     padding-left: $base-font-size * 12;
   }
 
@@ -26,15 +26,21 @@
     display: block;
     color: #999999;
 
-    @media (min-width: 48em) {
+    @media (min-width: 35.5em) {
+      float: left;
       display: inline-block;
       width: $base-font-size * 12;
+      margin-left: -$base-font-size * 12;
+      padding-right: $base-font-size;
       text-align: right;
-      margin-right: $base-font-size;
       position: relative;
-      left: -$base-font-size * 13;
-      margin-right: -$base-font-size * 12;
     }
+  }
+
+  // Remove any top spacing to ensure a smooth line from label to content.
+  label + * {
+    margin-top: 0;
+    padding-top: 0;
   }
 
   img {
@@ -49,7 +55,7 @@
   padding: $base-font-size 0;
   border-top: 2px solid #e8e8e8;
 
-  @media (min-width: 48em) {
+  @media (min-width: 35.5em) {
     padding-left: $base-font-size * 12;
   }
 
@@ -70,7 +76,7 @@
     padding: $base-font-size * 0.5 $base-font-size;
     padding-bottom: 0;
 
-    @media (min-width: 48em) {
+    @media (min-width: 35.5em) {
       padding-left: $base-font-size * 13;
     }
   }

--- a/app/assets/stylesheets/pure_admin/forms.css.scss
+++ b/app/assets/stylesheets/pure_admin/forms.css.scss
@@ -84,18 +84,26 @@
     padding: 0.55em;
   }
 
+  @mixin pure-form-indented {
+    @media (min-width: 35.5em) {
+      padding-left: $base-font-size * 12;
+    }
+  }
+
   .pure-controls {
     padding-top: $base-font-size;
     padding-bottom: $base-font-size;
     border-top: 2px solid #e8e8e8;
 
-    @media (min-width: 35.5em) {
-      padding-left: $base-font-size * 12;
-    }
+    @include pure-form-indented;
 
     .pure-button {
       margin-right: $base-font-size * 0.25;
     }
+  }
+
+  .pure-form-indented {
+    @include pure-form-indented;
   }
 }
 

--- a/app/assets/stylesheets/pure_admin/utilities.css.scss
+++ b/app/assets/stylesheets/pure_admin/utilities.css.scss
@@ -13,3 +13,12 @@
 .text-error {
   color: $text-error;
 }
+
+.text-muted {
+  color: $text-muted;
+
+  a {
+    color: inherit;
+    text-decoration: underline;
+  }
+}

--- a/app/assets/stylesheets/pure_admin/variables.css.scss
+++ b/app/assets/stylesheets/pure_admin/variables.css.scss
@@ -8,6 +8,7 @@ $black: #000;
 $grey-light: #efefef;
 $grey-medium: #d9d9d9;
 $grey-medium-dark: #cdcdcd;
+$grey-dark: #aaa;
 
 $text-success: #3c763d;
 $background-success: #c2e6b3;
@@ -24,3 +25,5 @@ $border-alert: #ddd6b2;
 $text-error: #a94442;
 $background-error: #e9c5c5;
 $border-error: #deb0b0;
+
+$text-muted: $grey-dark;

--- a/app/helpers/pure_admin/application_helper.rb
+++ b/app/helpers/pure_admin/application_helper.rb
@@ -1,0 +1,12 @@
+##
+# Generic helper methods to be used throughout the Pure application.
+module PureAdmin::ApplicationHelper
+  ##
+  # Merges two values into a new array while flattening and removing nils.
+  # @param value1 (String, Array)
+  # @param value2 (String, Array)
+  # @return (Array)
+  def merge_html_classes(value1, value2)
+    [value1, value2].flatten.compact
+  end
+end

--- a/app/helpers/pure_admin/details_panel_helper.rb
+++ b/app/helpers/pure_admin/details_panel_helper.rb
@@ -1,0 +1,53 @@
+##
+# Helper methods for the details panel.
+module PureAdmin::DetailsPanelHelper
+  ##
+  # Renders a "details panel" to the view.
+  # @param title (String)
+  # @param options (Hash) a container for options to be passed to the panel and panel body.
+  # @param options[:panel_html] (Hash) all options that can be passed to content_tag are respected here.
+  # @param options[:body_html] (Hash) all options that can be passed to content_tag are respected here.
+  # @yield The contents of the details panel
+  def details_panel(options = nil, &block)
+    options ||= {}
+
+    panel_html = options.delete(:panel_html) || {}
+    panel_html[:class] = merge_html_classes('details-panel', panel_html[:class])
+
+    body_html = options.delete(:body_html) || {}
+    body_html[:class] = merge_html_classes('details-panel-body pure-g', body_html[:class])
+
+    content_tag(:div, panel_html) do
+      content_tag(:div, '', body_html, &block)
+    end
+  end
+
+  ##
+  # Renders a "details panel item" to the view.
+  # @param label (String, Symbol)
+  # @param value (Any)
+  # @param options (Hash) all options that can be passed to content_tag are respected here.
+  # @yield The contents of the details panel item
+  def details_panel_item(label = nil, value = nil, options = nil, &block)
+    options, value = value, nil if block_given?
+
+    label = label.to_s.titleize unless label.nil? || label.respond_to?(:titleize)
+
+    options ||= {}
+    options[:class] = merge_html_classes('details-item pure-u-1', options[:class])
+
+    content_tag(:div, options) do
+      content_tag(:label, label) + (block_given? ? capture(&block) : value.to_s)
+    end
+  end
+
+  ##
+  # Renders a "details_panel_controls" element to the view.
+  # @param options (Hash) all options that can be passed to content_tag are respected here.
+  # @yield The contents of the details panel controls
+  def details_panel_controls(options = nil, &block)
+    options ||= {}
+    options[:class] = merge_html_classes('details-panel-controls pure-u-1', options[:class])
+    content_tag(:div, capture(&block), options)
+  end
+end

--- a/app/helpers/pure_admin/menu_helper.rb
+++ b/app/helpers/pure_admin/menu_helper.rb
@@ -12,10 +12,10 @@ module PureAdmin::MenuHelper
     options ||= {}
 
     menu_html = options.delete(:menu_html) || {}
-    menu_html[:class] = merge_options('pure-menu', menu_html[:class])
+    menu_html[:class] = merge_html_classes('pure-menu', menu_html[:class])
 
     list_html = options.delete(:list_html) || {}
-    list_html[:class] = merge_options('pure-menu-list', list_html[:class])
+    list_html[:class] = merge_html_classes('pure-menu-list', list_html[:class])
 
     content_tag(:nav, menu_html) do
       content_tag(:ul, '', list_html, &block)
@@ -36,14 +36,14 @@ module PureAdmin::MenuHelper
     options ||= {}
 
     item_html = options.delete(:item_html) || {}
-    item_html[:class] = merge_options('pure-menu-item', item_html[:class])
+    item_html[:class] = merge_html_classes('pure-menu-item', item_html[:class])
     # TODO: Properly handle current page to take into account multi-level menus.
     if url.present? && ( current_page?(url) || name.to_s.downcase == controller_name )
       item_html[:class] << 'current'
     end
 
     link_html = options.delete(:link_html) || {}
-    link_html[:class] = merge_options('pure-menu-link', link_html[:class])
+    link_html[:class] = merge_html_classes('pure-menu-link', link_html[:class])
 
     content_tag(:li, item_html) do
       if url.present?
@@ -77,10 +77,4 @@ module PureAdmin::MenuHelper
   def menu_item_unless(condition, name = nil, url = nil, options = nil, &block)
     menu_item_if(!condition, name, url, options, &block)
   end
-
-  private
-
-    def merge_options(value1, value2)
-      [value1, value2].flatten.compact
-    end
 end

--- a/spec/helpers/pure_admin/details_panel_helper_spec.rb
+++ b/spec/helpers/pure_admin/details_panel_helper_spec.rb
@@ -1,0 +1,154 @@
+require 'rails_helper'
+
+describe PureAdmin::DetailsPanelHelper do
+  describe '#details_panel' do
+    context 'with a block' do
+      subject(:html) { helper.details_panel { 'block content' } }
+
+      it 'renders a .details-panel element' do
+        expect(html).to have_selector('div.details-panel')
+      end
+
+      it 'renders a .details-panel-body element inside the .details-panel element' do
+        expect(html).to have_selector('div.details-panel div.details-panel-body')
+      end
+
+      it 'renders the block within the .details-panel-body element' do
+        expect(html).to have_selector('div.details-panel div.details-panel-body', text: 'block content')
+      end
+
+      it 'does not render a title' do
+        expect(html).to_not have_selector('div.details-panel div.details-panel-title h4')
+      end
+
+      context 'specifically with options' do
+        subject(:html) {
+          helper.details_panel(panel_html: { data: { options: 'panel' } },
+            body_html: { data: { options: 'body' } }) { 'block content' }
+        }
+
+        it 'uses panel_html as html attributes on the .details-panel element' do
+          expect(html).to have_selector('div.details-panel[data-options="panel"]')
+        end
+
+        it 'uses body_html as html attributes on the .details-panel-body element' do
+          expect(html).to have_selector('div.details-panel div.details-panel-body[data-options="body"]')
+        end
+
+        it 'renders the block within the .details-panel-body element' do
+          expect(html).to have_selector('div.details-panel div.details-panel-body', text: 'block content')
+        end
+      end
+    end
+  end
+
+  describe '#details_panel_item' do
+    context 'with a label, value, and options' do
+      subject(:html) { helper.details_panel_item(:label_symbol, 'value', data: { options: true }) }
+
+      it 'renders a .details-item element' do
+        expect(html).to have_selector('div.details-item')
+      end
+
+      it 'renders a titleized label inside the .details-item element' do
+        expect(html).to have_selector('div.details-item label', text: 'Label Symbol')
+      end
+
+      it 'renders the value inside the .details-item element' do
+        expect(html).to have_selector('div.details-item', text: /value/)
+      end
+
+      it 'uses options as html attributes' do
+        expect(html).to have_selector('div.details-item[data-options="true"]')
+      end
+
+      context 'when the label is given as a string' do
+        subject(:html) {
+          helper.details_panel_item('a Specifically-Cased string', 'value', data: { options: true })
+        }
+
+        it 'leaves the letter case as given' do
+          expect(html).to have_selector('div.details-item label', text: 'a Specifically-Cased string')
+        end
+      end
+    end
+
+    context 'with a string argument, options, and block' do
+      subject(:html) { helper.details_panel_item('argument', data: { options: true }) { 'block' } }
+
+      it 'uses the first argument as a label' do
+        expect(html).to have_selector('div.details-item label', text: 'argument')
+      end
+
+      it 'uses the supplied block' do
+        expect(html).to have_selector('div.details-item', text: /block/)
+      end
+
+      it 'detects the options and uses them as html attributes' do
+        expect(html).to have_selector('div.details-item[data-options="true"]')
+      end
+    end
+
+    context 'with a label and a value' do
+      subject(:html) { helper.details_panel_item(:label_symbol, 'value') }
+
+      it 'contains the label' do
+        expect(html).to have_selector('div.details-item label', text: /Label Symbol/)
+      end
+
+      it 'contains the value' do
+        expect(html).to have_selector('div.details-item', text: /value/)
+      end
+    end
+
+    context 'with a single string or symbol argument and a block' do
+      subject(:html) { helper.details_panel_item('single argument') { 'block' } }
+
+      it 'takes the argument as a label' do
+        expect(html).to have_selector('div.details-item label', text: 'single argument')
+      end
+
+      it 'uses the supplied block' do
+        expect(html).to have_selector('div.details-item', text: /block/)
+      end
+    end
+
+    context 'with a single sting or symbol argument' do
+      subject(:html) { helper.details_panel_item('only one') }
+
+      it 'takes the argument as a label' do
+        expect(html).to have_selector('div.details-item label', text: 'only one')
+      end
+    end
+
+    context 'with only a block' do
+      subject(:html) { helper.details_panel_item { 'block' } }
+
+      it 'uses the supplied block' do
+        expect(html).to have_selector('div.details-item', text: /block/)
+      end
+
+      it 'produces a blank label' do
+        expect(html).to have_selector('div.details-item label', text: '')
+      end
+    end
+  end
+
+  describe '#details_panel_controls' do
+    subject(:html) { helper.details_panel_controls { 'pear' } }
+
+    it { is_expected.to have_selector('div.details-panel-controls') }
+
+    it 'uses the supplied block' do
+      expect(html).to have_selector('.details-panel-controls', text: /pear/)
+    end
+
+    context 'but with options' do
+      subject(:html) { helper.details_panel_controls(data: { options: true }) { 'pear' } }
+
+      it 'uses the options as html attributes' do
+        expect(html).to have_selector('div.details-panel-controls[data-options="true"]')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This helper allows the building of details panels complete with their items
and controls.

Also committed is a helper class to allow for aligned content within a form, and a `text-muted` class to allow for greyed-out text. Examples of both can be seen below. 

![screen shot 2016-01-06 at 12 09 19](https://cloud.githubusercontent.com/assets/5688326/12132794/38e8bce4-b46f-11e5-9b16-ee0759cead77.png)
