### PR TITLE
Add menu builder helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-# Ignore private files
-secrets.yml
-database.yml
-
 # Ignore bundler config.
 /.bundle
 

--- a/app/helpers/pure_admin/menu_helper.rb
+++ b/app/helpers/pure_admin/menu_helper.rb
@@ -1,0 +1,111 @@
+
+##
+# Helper methods to assist in building the Pure Admin menu.
+module PureAdmin::MenuHelper
+  ##
+  # Renders a pure menu wrapper to the view.
+  # @param options (Hash) all options that can be passed to content_tag are respected here.
+  # @param options[:animate] (Boolean) if this is false the 'with-animation' class will not be
+  #   applied to the nested ul.
+  # @param options[:horizontal] (Boolean) if this is false, the 'pure-menu-horizontal' class will
+  #   not be applied to the wrapper tag.
+  # @param options[:fixed] (Boolean) if this is false, the 'pure-menu-fixed' class will not be
+  #   applied to the wrapper tag.
+  # @param options[:main_menu] (Boolean) if this is false and no :id key has been supplied, the id
+  #   'main-menu' will not be applied to the wrapper tag.
+  # @yield The contents of the menu panel
+  def menu(options = nil, &block)
+    fail ArgumentError, 'You must supply a block.' unless block_given?
+
+    if options
+      opts = options.dup
+    else
+      opts = {}
+    end
+
+    inner_classes = ['pure-menu-list']
+    inner_classes << 'with-animation' unless opts.delete(:animate) == false
+    inner = content_tag(:ul, capture(&block), class: inner_classes)
+
+    wrapper_classes = ['pure-menu']
+    wrapper_classes << 'pure-menu-horizontal' unless opts.delete(:horizontal) == false
+    wrapper_classes << 'pure-menu-fixed' unless opts.delete(:fixed) == false
+
+    unless opts.delete(:main_menu) == false
+      %w(left right).each do |dir|
+        inner << content_tag(:div, content_tag(:span, nil, class: "fa fa-angle-double-#{dir}"),
+          class: "fade-#{dir}", rel: 'main-menu-scroll', data: { direction: dir })
+      end
+
+      opts[:id] = 'main-menu' unless opts[:id].present?
+    end
+
+    opts[:class] = "#{wrapper_classes.join(' ')} #{opts[:class]}".strip
+    content_tag(:div, content_tag(:nav, inner), opts)
+  end
+
+  ##
+  # Renders a "menu item" to the view.
+  # @param label (String, Symbol)
+  # @param destination (String, Array)
+  # @param options (Hash) all options that can be passed to content_tag are respected here.
+  # @param options[:icon] (String, Symbol) a FontAwesome icon name that will be prepended to the
+  #   label.
+  def menu_item(label = nil, destination = nil, options = nil, &block)
+    if label.is_a?(Hash) && destination.nil? && options.nil? && block_given?
+      # eg. menu_item(class: 'testing') do ...
+      opts = label.dup
+      label = nil
+      destination = '#'
+    elsif label.is_a?(Hash) && destination.nil? && options.nil? && !block_given?
+      # eg. menu_item(class: 'testing')
+      fail ArgumentError, 'Cannot build a menu item with only an options hash'
+    elsif label.present? && destination.is_a?(Hash) && options.nil? && block_given?
+      # eg. menu_item('destination', class: 'testing') do ...
+      opts = destination.dup
+      destination = label.to_s
+      label = nil
+    elsif label.present? && destination.is_a?(Hash) && options.nil? && !block_given?
+      # eg. menu_item('destination', class: 'testing')
+      opts = destination.dup
+      destination = '#'
+    elsif label.present? && destination.nil? && options.nil? && !block_given?
+      # eg. menu_item 'destination'
+      destination = '#'
+      opts = {}
+    elsif label.present? && destination.nil? && block_given?
+      # eg. menu_item 'destination' do ...
+      destination = label
+      label = nil
+      opts = options || {}
+    elsif label.nil? && destination.nil? && options.nil? && block_given?
+      # eg. menu_item do ...
+      label = nil
+      destination = '#'
+      opts = {}
+    elsif options
+      opts = options.dup
+    else
+      opts = {}
+    end
+
+    fail ArgumentError, 'cannot supply both a label and a block' if label.present? && block_given?
+
+    label = label.is_a?(Symbol) ? label.to_s.titleize : label
+
+    link_text = ''.html_safe
+    icon = opts.delete(:icon)
+    link_text << content_tag(:i, nil, class: "fa fa-#{icon}") if icon.present?
+    link_text << (block_given? ? capture(&block) : label)
+
+    link_class = 'pure-menu-link'
+    # TODO: when the implementation for multi-level menus is complete, consider what the parent
+    # should do when children are current.
+    link_class << ' current' if current_page?(destination) || label.to_s.downcase == controller_name
+
+    link = link_to(link_text, destination, class: link_class)
+
+    opts[:class] = "pure-menu-item #{opts[:class]}"
+    content_tag(:li, link, opts)
+  end
+end

--- a/spec/helpers/pure_admin/menu_helper_spec.rb
+++ b/spec/helpers/pure_admin/menu_helper_spec.rb
@@ -1,0 +1,299 @@
+require 'rails_helper'
+
+describe PureAdmin::MenuHelper do
+  describe '#menu' do
+    context 'without a block' do
+      it 'raises an error' do
+        expect {
+          menu
+        }.to raise_error(ArgumentError, 'You must supply a block.')
+      end
+    end
+
+    context 'with a block' do
+      subject(:html) { menu { 'link to Google' } }
+
+      it 'renders a main wrapper tag' do
+        expect(html).to have_selector('div.pure-menu')
+      end
+
+      it 'renders an inner nav tag' do
+        expect(html).to have_selector('div.pure-menu nav')
+      end
+
+      it 'renders a ul inside the nav tag' do
+        expect(html).to have_selector('nav ul.pure-menu-list')
+      end
+
+      it 'renders the block within the ul' do
+        expect(html).to have_selector('nav ul.pure-menu-list', text: 'link to Google')
+      end
+
+      context 'specifically without options' do
+        it 'gives the main wrapper tag an id of main-menu' do
+          expect(html).to have_selector('.pure-menu#main-menu')
+        end
+
+        it 'gives the main wrapper tag a class of pure-menu-horizontal' do
+          expect(html).to have_selector('.pure-menu.pure-menu-horizontal')
+        end
+
+        it 'gives the main wrapper tag a class of pure-menu-fixed' do
+          expect(html).to have_selector('.pure-menu.pure-menu-fixed')
+        end
+
+        it 'gives the ul a class of with-animation' do
+          expect(html).to have_selector('ul.pure-menu-list.with-animation')
+        end
+
+        it 'renders the left/right elements to be used for scrolling' do
+          expect(html).
+            to have_selector('.pure-menu .fade-left[rel="main-menu-scroll"][data-direction="left"]')
+
+          expect(html).
+            to have_selector('.pure-menu .fade-right[rel="main-menu-scroll"][data-direction="right"]')
+        end
+      end
+
+      context 'specifically with options' do
+        subject(:html) { menu(data: { google: true }) { 'link to Google' } }
+
+        it 'uses options as html attributes on the main wrapper tag' do
+          expect(html).to have_selector('.pure-menu[data-google="true"]')
+        end
+
+        context 'when options[:animate] is passed as false' do
+          subject(:html) { menu(animate: false) { 'link to Google' } }
+
+          it 'does not give the ul a class of with-animation' do
+            expect(html).to_not have_selector('ul.pure-menu-list.with-animation')
+          end
+        end
+
+        context 'when options[:horizontal] is passed as false' do
+          subject(:html) { menu(horizontal: false) { 'link to Google' } }
+
+          it 'does not give the main wrapper tag a class of pure-menu-horizontal' do
+            expect(html).to_not have_selector('.pure-menu.pure-menu-horizontal')
+          end
+        end
+
+        context 'when options[:fixed] is passed as false' do
+          subject(:html) { menu(fixed: false) { 'link to Google' } }
+
+          it 'does not give the main wrapper tag a class of pure-menu-fixed' do
+            expect(html).to_not have_selector('.pure-menu.pure-menu-fixed')
+          end
+        end
+
+        context 'when options[:main_menu] is passed as false' do
+          subject(:html) { menu(main_menu: false) { 'link to Google' } }
+
+          it 'does not give the main wrapper tag an id of main-menu' do
+            expect(html).to_not have_selector('.pure-menu#main-menu')
+          end
+
+          it 'does not render the left/right elements to be used for scrolling' do
+            expect(html).to_not have_selector('.pure-menu .fade-left')
+            expect(html).to_not have_selector('.pure-menu .fade-right')
+          end
+        end
+
+        context 'when options[:main_menu] is not false and options[:id] is given' do
+          subject(:html) { menu(id: 'my-own-id') { 'link to Google' } }
+
+          it 'uses the given id' do
+            expect(html).to have_selector('.pure-menu#my-own-id')
+          end
+
+          it 'does not overwrite the default id (#main-menu)' do
+            expect(html).to_not have_selector('.pure-menu#main-menu')
+          end
+
+          it 'still renders the left/right elements to be used for scrolling' do
+            expect(html).to have_selector('.pure-menu .fade-left')
+            expect(html).to have_selector('.pure-menu .fade-right')
+          end
+        end
+      end
+    end
+  end
+
+  describe '#menu-item' do
+    context 'with a label, destination, options, and block' do
+      it 'raises an argument error' do
+        expect {
+          helper.menu_item(:label, 'dest', options: true) { 'block' }
+        }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'with a label, destination, and options' do
+      subject(:html) { helper.menu_item(:label_symbol, 'dest', data: { options: true }) }
+
+      it 'creates a link with the label as the link text' do
+        expect(html).to have_selector('a.pure-menu-link', text: /Label Symbol/)
+      end
+
+      it 'creates a link with the destination as the href' do
+        expect(html).to have_selector('a.pure-menu-link[href="dest"]')
+      end
+
+      it 'uses options as html attributes for the wrapping li' do
+        expect(html).to have_selector('li.pure-menu-item[data-options="true"]')
+      end
+
+      context 'when the label is given as a string' do
+        subject(:html) {
+          helper.menu_item('a Specifically-Cased string', 'dest', data: { options: true })
+        }
+
+        it 'leaves the letter case as given' do
+          expect(html).to have_selector('a.pure-menu-link', text: 'a Specifically-Cased string')
+        end
+      end
+    end
+
+    context 'with a label, destination, and block' do
+      it 'raises an argument error' do
+        expect {
+          helper.menu_item(:label, 'destination', options: true) { 'block' }
+        }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'with a string or symbol argument, options, and block' do
+      subject(:html) { helper.menu_item(:argument, data: { options: true }) { 'block' } }
+
+      it 'uses the first argument as the destination and creates a link with this as the href' do
+        expect(html).to have_selector('a.pure-menu-link[href="argument"]')
+      end
+
+      it 'creates a link with the block as the link text' do
+        expect(html).to have_selector('a.pure-menu-link', text: /block/)
+      end
+
+      it 'uses options as html attributes for the wrapping li' do
+        expect(html).to have_selector('li.pure-menu-item[data-options="true"]')
+      end
+    end
+
+    context 'with a label and a destination' do
+      subject(:html) { helper.menu_item(:label_symbol, 'dest') }
+
+      it 'creates a link with the label as the link text' do
+        expect(html).to have_selector('a.pure-menu-link', text: /Label Symbol/)
+      end
+
+      it 'creates a link with the destination as the href' do
+        expect(html).to have_selector('a.pure-menu-link[href="dest"]')
+      end
+    end
+
+    context 'with a single string or symbol argument and options' do
+      # could be label + options or destination + options
+      subject(:html) { helper.menu_item('single argument', data: { options: true }) }
+
+      it 'takes the first argument as a label and creates a link with this as the link text' do
+        expect(html).to have_selector('a.pure-menu-link', text: /single argument/)
+      end
+
+      it 'uses options as html attributes for the wrapping li' do
+        expect(html).to have_selector('li.pure-menu-item[data-options="true"]')
+      end
+    end
+
+    context 'with a single string or symbol argument and a block' do
+      subject(:html) { helper.menu_item('single argument') { 'block' } }
+
+      it 'uses the first argument as the destination and creates a link with this as the href' do
+        expect(html).to have_selector('a.pure-menu-link[href="single argument"]')
+      end
+
+      it 'creates a link with the block as the link text' do
+        expect(html).to have_selector('a.pure-menu-link', text: /block/)
+      end
+    end
+
+    context 'with options and a block' do
+      subject(:html) { helper.menu_item(data: { options: true }) { 'block' } }
+
+      it 'detects the options and uses them as html attributes for the wrapping li' do
+        expect(html).to have_selector('li.pure-menu-item[data-options="true"]')
+      end
+
+      it 'creates a link with the block as the link text' do
+        expect(html).to have_selector('a.pure-menu-link', text: /block/)
+      end
+
+      it 'creates a link with # as the href' do
+        expect(html).to have_selector('a.pure-menu-link[href="#"]')
+      end
+    end
+
+    context 'with a single sting or symbol argument' do
+      subject(:html) { helper.menu_item('only one') }
+
+      it 'uses the first argument as the label and creates a link with this as the link text' do
+        expect(html).to have_selector('a.pure-menu-link', text: /only one/)
+      end
+
+      it 'creates a link with # as the href' do
+        expect(html).to have_selector('a.pure-menu-link[href="#"]')
+      end
+    end
+
+    context 'with a single hash argument' do
+      subject(:html) { helper.menu_item(data: { options: true }) }
+
+      it 'it raises an argument error' do
+        expect { html }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'with only a block' do
+      subject(:html) { helper.menu_item { 'block' } }
+
+      it 'uses the first argument as the label and creates a link with this as the link text' do
+        expect(html).to have_selector('a.pure-menu-link', text: /block/)
+      end
+
+      it 'creates a link with # as the href' do
+        expect(html).to have_selector('a.pure-menu-link[href="#"]')
+      end
+    end
+
+    context 'when icon is given in the options' do
+      subject(:html) { helper.menu_item('destination', icon: :pencil) { 'block' } }
+
+      it 'contains the correct FontAwesome element' do
+        expect(html).to have_selector('a.pure-menu-link .fa.fa-pencil')
+      end
+    end
+
+    context 'when the requested page matches the destination passed in' do
+      subject(:html) { helper.menu_item('http://test.host:3000') { 'block' } }
+
+      before do
+        helper.request.host = 'test.host:3000'
+      end
+
+      it 'applies the class of current to the link' do
+        expect(html).to have_selector('a.pure-menu-link.current[href="http://test.host:3000"]')
+      end
+    end
+
+    context 'when the given label matches the controller_name' do
+      subject(:html) { helper.menu_item('tests', 'something-else') }
+
+      before do
+        class TestsController < ActionController::Base; end
+        helper.controller = TestsController
+      end
+
+      it 'applies the class of current to the link' do
+        expect(html).to have_selector('a.pure-menu-link.current[href="something-else"]')
+      end
+    end
+  end
+end

--- a/spec/test_app/config/database.yml
+++ b/spec/test_app/config/database.yml
@@ -1,0 +1,25 @@
+# SQLite version 3.x
+#   gem install sqlite3
+#
+#   Ensure the SQLite 3 gem is defined in your Gemfile
+#   gem 'sqlite3'
+#
+default: &default
+  adapter: sqlite3
+  pool: 5
+  timeout: 5000
+
+development:
+  <<: *default
+  database: db/development.sqlite3
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  <<: *default
+  database: db/test.sqlite3
+
+production:
+  <<: *default
+  database: db/production.sqlite3

--- a/spec/test_app/config/secrets.yml
+++ b/spec/test_app/config/secrets.yml
@@ -1,0 +1,5 @@
+development:
+  secret_key_base: 'a dummy secret key'
+
+test:
+  secret_key_base: 'a dummy secret key'


### PR DESCRIPTION
This helper allows the building of PureCSS-compatible menus complete
with their menu items.

This commit additionally adds the test app's database.yml and secrets.yml files
to allow the running of specs without having to add the files manually.
As it's only an app meant for running tests on, I don't see this as a problem.
