### PR TITLE
Provide the input plugin system

### DIFF
--- a/app/assets/javascripts/pure_admin/inputs.js
+++ b/app/assets/javascripts/pure_admin/inputs.js
@@ -1,0 +1,20 @@
+var PureAdmin = PureAdmin || {};
+
+PureAdmin.inputs = {
+  initAll: function(context) {
+    for (var inputType in PureAdmin.inputs) {
+      inputTypeObj = PureAdmin.inputs[inputType];
+      if (typeof(inputTypeObj) === 'object') {
+        inputTypeObj.init();
+      }
+    }
+  }
+};
+
+$(document).ready(function(context) {
+  PureAdmin.inputs.initAll(context);
+});
+
+$(document).on('ajaxSuccess', function(context) {
+  PureAdmin.inputs.initAll(context);
+});


### PR DESCRIPTION
Each input should check for the existance of the PureAdmin object
at the beginning of its JavaScript file:

``` js
if (!PureAdmin) {
  console.error('You must load the PureAdmin JavaScript first before loading this JavaScript.');
}
```

Then it can build itself into the `PureAdmin.inputs` object like so:

``` js
PureAdmin.inputs.autocompleter = {
  init: function(context) {
    ...
  }
};
```

Every input must have an `init` function and this will be called on page load
and ajaxSuccess. It is up to the input JavaScript itself to detect if an element
has already been initialised.
