### PR TITLE
Portlet helper now uses options for body_html and heading_html

### DIFF
--- a/app/assets/stylesheets/pure_admin/details_panels.css.scss
+++ b/app/assets/stylesheets/pure_admin/details_panels.css.scss
@@ -23,6 +23,10 @@
 
   @media (min-width: 35.5em) {
     padding-left: $base-font-size * 12;
+
+    &.not-aligned {
+      padding-left: $base-font-size;
+    }
   }
 
   label {
@@ -85,6 +89,10 @@
 
     @media (min-width: 35.5em) {
       padding-left: $base-font-size * 13;
+
+      &.not-aligned {
+        padding-left: $base-font-size;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/pure_admin/portlets.css.scss
+++ b/app/assets/stylesheets/pure_admin/portlets.css.scss
@@ -48,7 +48,6 @@ $icon-minus: '\f068';
               transition: all 0.2s linear;
     }
   }
-
 }
 
 .portlet-heading {
@@ -118,4 +117,16 @@ $icon-minus: '\f068';
   display: none;
   font-size: 14px;
   padding: 0 $base-font-size;
+
+  &.vertically-padded {
+    padding: 16px;
+  }
+
+  &.top-padded {
+    padding-top: 16px;
+  }
+
+  &.bottom-padded {
+    padding-bottom: 16px;
+  }
 }

--- a/app/helpers/pure_admin/portlet_helper.rb
+++ b/app/helpers/pure_admin/portlet_helper.rb
@@ -12,12 +12,14 @@ module PureAdmin::PortletHelper
   def portlet(title, options = {}, &block)
     portlet_html = options[:portlet_html] || {}
     portlet_html[:class] = ['portlet', portlet_html[:class]]
-    portlet_html[:data] = portlet_html[:data] || {}
+    portlet_html[:data] ||= {}
     portlet_html[:data][:source] = options[:source] unless block_given?
 
     heading_html = options.delete(:heading_html) || {}
+    heading_html[:class] = merge_html_classes('portlet-heading', heading_html[:class])
 
     body_html = options.delete(:body_html) || {}
+    body_html[:class] = merge_html_classes('portlet-body clear-fix', body_html[:class])
 
     icon = content_tag(:i, nil, class: "portlet-heading-icon fa fa-fw fa-#{options[:icon]}") if options[:icon]
 
@@ -34,7 +36,7 @@ module PureAdmin::PortletHelper
       end
     end
 
-    # This determines if the portlet should be expanded by default. If if is explicitly given that
+    # This determines if the portlet should be expanded by default. If it is explicitly given that
     # takes precedence. If not, by default all remote portlets are not expanded and all static
     # portlets are.
     expand = options.key?(:expand) ? options[:expand] : block_given?
@@ -44,13 +46,11 @@ module PureAdmin::PortletHelper
       portlet_html[:data][:expand] = true
     end
 
-    heading_content = content_tag(:div, class: 'portlet-heading') do
+    heading_content = content_tag(:div, heading_html) do
       ( icon || ''.html_safe ) + content_tag(:h4, title) + ( controls_content || ''.html_safe )
     end
 
-    body_content = content_tag(:div, (capture(&block) if block_given?), { class: 'portlet-body clear-fix' })
-
-    portlet_html[:class] = portlet_html[:class].flatten.compact
+    body_content = content_tag(:div, (capture(&block) if block_given?), body_html)
 
     content_tag(:div, portlet_html) do
       heading_content + body_content

--- a/spec/helpers/pure_admin/portlet_helper_spec.rb
+++ b/spec/helpers/pure_admin/portlet_helper_spec.rb
@@ -48,7 +48,7 @@ describe PureAdmin::PortletHelper do
         subject(:html) { helper.portlet('apples', icon: :pencil) { 'banana' } }
 
         it 'contains the correct FontAwesome element' do
-          expect(html).to have_selector('.portlet-heading h4 .fa.fa-fw.fa-pencil')
+          expect(html).to have_selector('.portlet-heading-icon.fa.fa-fw.fa-pencil')
         end
       end
     end
@@ -80,8 +80,32 @@ describe PureAdmin::PortletHelper do
         subject(:html) { helper.portlet('apples', source: 'google.com', icon: :pencil) }
 
         it 'contains the correct FontAwesome element' do
-          expect(html).to have_selector('.portlet-heading h4 .fa.fa-fw.fa-pencil')
+          expect(html).to have_selector('.portlet-heading-icon.fa.fa-fw.fa-pencil')
         end
+      end
+    end
+
+    context 'when heading_html is passed in' do
+      it 'adds the class to the heading' do
+        expect(helper.portlet('Peaches', heading_html: { class: 'fuzzy' })).to \
+          have_selector('.portlet-heading.fuzzy')
+      end
+
+      it 'adds other attributes (ie: data)' do
+        expect(helper.portlet('Peaches', heading_html: { data: { pits: true } })).to \
+          have_selector('.portlet-heading[data-pits]')
+      end
+    end
+
+    context 'when body_html is passed in' do
+      it 'adds the class to the body' do
+        expect(helper.portlet('Peaches', body_html: { class: 'fuzzy' })).to \
+          have_selector('.portlet-body.fuzzy')
+      end
+
+      it 'adds other attributes (ie: data)' do
+        expect(helper.portlet('Peaches', body_html: { data: { pits: true } })).to \
+          have_selector('.portlet-body[data-pits]')
       end
     end
   end


### PR DESCRIPTION
The portlet helper was not actually using the body_html or heading_html options passed into it. I've added this functionality and a few specs checking it works.

I've also added a couple of useful classes specifically for portlets.
