### PR TITLE
Use Select2 for all collection selects

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ gem 'pure-css-reset-rails', github: 'blaknite/pure-css-reset-rails', branch: 'ma
 gem 'exo2-rails', github: 'blaknite/exo2-rails', branch: 'master'
 gem 'crummy', github: 'blaknite/crummy', branch: 'master'
 gem 'font-awesome-rails'
+gem 'select2-rails'
 gem 'pure-css-rails'
 ```
 
@@ -25,7 +26,10 @@ rails generate pure_admin:simple_form
 Then edit ```app/views/layouts/admin.html.erb``` to your liking.
 
 ## Dependencies
-Pure CSS, jQuery and waypoints.js.
+- Pure CSS
+- jQuery
+- waypoints.js
+- [Select2](https://select2.github.io/)
 
 ## Usage
 ### Portlets

--- a/app/assets/javascripts/pure_admin/inputs/select.js
+++ b/app/assets/javascripts/pure_admin/inputs/select.js
@@ -1,0 +1,21 @@
+if (!PureAdmin) {
+  console.error('You must load the PureAdmin JavaScript first before loading this JavaScript.');
+}
+
+PureAdmin.inputs.select = {
+  init: function(context) {
+    $('.pure-admin-select').select2({
+      theme: 'pure-admin',
+      templateResult: PureAdmin.inputs.select.formatResult,
+      templateSelection: PureAdmin.inputs.select.formatResult,
+
+      escapeMarkup: function(markup) {
+        return markup;
+      },
+    });
+  },
+
+  formatResult: function(result) {
+    return result.name || result.text || '<span class="text-muted">(blank)</span>'
+  }
+};

--- a/app/assets/stylesheets/pure_admin.css.scss
+++ b/app/assets/stylesheets/pure_admin.css.scss
@@ -18,3 +18,4 @@
 @import 'pure_admin/scopes.css.scss';
 @import 'pure_admin/auth.css.scss';
 @import 'pure_admin/modals.css.scss';
+@import 'pure_admin/inputs/*'

--- a/app/assets/stylesheets/pure_admin/inputs/select.css.scss
+++ b/app/assets/stylesheets/pure_admin/inputs/select.css.scss
@@ -1,0 +1,85 @@
+.select2-container--pure-admin {
+  display: table !important;
+  table-layout: fixed;
+
+  .select2-selection {
+    color: inherit;
+    border: 1px solid $input-border;
+    box-shadow: none;
+    border-radius: 0;
+    height: 2.5em !important;
+
+    &:focus {
+      outline: 0;
+    }
+
+    .select2-selection__arrow {
+      height: 2.3em;
+      position: absolute;
+      right: 1px;
+      top: 1px;
+      width: 20px;
+
+      b {
+        border-color: $text-color transparent transparent transparent;
+        border-style: solid;
+        border-width: 5px 4px 0 4px;
+        height: 0;
+        left: 50%;
+        margin-left: -4px;
+        margin-top: -2px;
+        position: absolute;
+        top: 50%;
+        width: 0;
+      }
+    }
+  }
+
+  .select2-selection__rendered {
+    line-height: 2.3em;
+    padding-left: 0.6em;
+  }
+
+  .select2-dropdown {
+    color: inherit;
+    font-size: 14px;
+    border: 1px solid $input-border;
+    border-top: 0;
+    border-radius: 0;
+
+    box-shadow: 0 1px 5px 0 $input-border;
+
+    .select2-search__field {
+      padding: 0.5em 0.6em;
+      &:focus {
+        outline: 0;
+        border: 1px solid $input-active;
+      }
+    }
+
+    .select2-results {
+      .select2-results__option {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+
+        &.select2-results__option--highlighted {
+          color: $white;
+          background-color: $input-active;
+        }
+      }
+    }
+  }
+
+  &.select2-container--open {
+    .select2-selection--single {
+      .select2-selection__arrow {
+        height: 2.2em;
+        b {
+          border-color: transparent transparent #555 transparent;
+          border-width: 0 4px 5px 4px;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/pure_admin/variables.css.scss
+++ b/app/assets/stylesheets/pure_admin/variables.css.scss
@@ -5,6 +5,8 @@ $base-font-size: 16px;
 $white: #fff;
 $black: #000;
 
+$text-color: #555;
+
 $menu-color: #50a8d1;
 
 $link-color: #50a8d1;
@@ -31,3 +33,6 @@ $background-error: #e9c5c5;
 $border-error: #deb0b0;
 
 $text-muted: $grey-dark;
+
+$input-border: #ccc;
+$input-active: #4a9fc8;

--- a/app/inputs/collection_select_input.rb
+++ b/app/inputs/collection_select_input.rb
@@ -1,0 +1,14 @@
+##
+# Overrides SimpleForm's default CollectionSelectInput to add a class.
+# This class is then used to initialise Select2 on all collection select inputs.
+class CollectionSelectInput < SimpleForm::Inputs::CollectionSelectInput
+  def input_html_classes
+    super.push('pure-admin-select')
+  end
+
+  def input_html_options
+    super.deep_merge(
+      style: 'width: 100%;'
+    )
+  end
+end

--- a/pure-admin.gemspec
+++ b/pure-admin.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
   s.add_dependency "exo2-rails"
   s.add_dependency "crummy"
   s.add_dependency "simple_form"
+  s.add_dependency 'select2-rails'
 end


### PR DESCRIPTION
This commit enables Select2 to be used on all collection selects
generated via SimpleForm. Additionally, any select with the class
of `pure-admin-select` will be initialised with Select2 as well.
