### PR TITLE
Fixes an issue when many portlets are loaded at once

### DIFF
--- a/app/assets/javascripts/pure_admin/portlets.js
+++ b/app/assets/javascripts/pure_admin/portlets.js
@@ -1,6 +1,9 @@
 var PureAdmin = PureAdmin || {};
 
 PureAdmin.portlets = {
+
+  loadingTimer: {},
+
   /*
    * Toggles the 'expanded' class for the clicked portlet if it is closable.
    * Additionally calls the loadPortlet function if the portlet is now expanded.
@@ -51,7 +54,7 @@ PureAdmin.portlets = {
       return;
     }
 
-    PureAdmin.portlets.loading(portlet, true);
+    PureAdmin.portlets.loading(portlet, true, source);
 
     $.ajax(source, {
       success: function(data, textStatus, jqXHR) {
@@ -62,7 +65,7 @@ PureAdmin.portlets = {
       },
       complete: function(jxXHR, textStatus) {
         portlet.data('body-loaded', true);
-        PureAdmin.portlets.loading(portlet, false);
+        PureAdmin.portlets.loading(portlet, false, source);
       }
     });
   },
@@ -73,14 +76,15 @@ PureAdmin.portlets = {
    * @param elem (jQuery Object)
    * @param loading (Boolean)
    */
-  loading: function(elem, loading) {
+  loading: function(elem, loading, uniqueId) {
     if (loading !== false) {
-      PureAdmin.portlets.loadingTimer = setTimeout(function() {
+      PureAdmin.portlets.loadingTimer[uniqueId] = setTimeout(function() {
         // if the wait is longer than the loading timeout we show a loading animation
         elem.addClass('loading');
       }, PureAdmin.LOADING_TIMEOUT);
     } else {
-      clearTimeout(PureAdmin.portlets.loadingTimer);
+      clearTimeout(PureAdmin.portlets.loadingTimer[uniqueId]);
+      delete PureAdmin.portlets.loadingTimer[uniqueId];
       elem.removeClass('loading');
     }
   },

--- a/app/assets/javascripts/pure_admin/table_filters.js
+++ b/app/assets/javascripts/pure_admin/table_filters.js
@@ -1,0 +1,50 @@
+(function() {
+  var loadingTimer;
+
+  $(document).on('ajax:beforeSend', '.table-filters, .pure-table, .pagination', function(e, data) {
+    loading(parentWrapper($(e.currentTarget)), true);
+    e.stopPropagation();
+  });
+
+  $(document).on('ajax:success', '.table-filters, .pure-table, .pagination', function(e, data) {
+    var wrapper = parentWrapper($(e.currentTarget));
+    wrapper.html(data);
+    loading(wrapper, false);
+    e.stopPropagation();
+  });
+
+  $(document).on('ajax:error', '.table-filters, .pure-table, .pagination', function(e, xhr, status, thrown) {
+    PureAdmin.flashMessages.create('error', thrown || 'Error');
+    loading(parentWrapper($(e.currentTarget)), false);
+    e.stopPropagation();
+  });
+
+  /*
+   * Return the appropriate parent of the target element.
+   * If the target element is within a portlet, return the portlet. If not, return the main-content
+   * div.
+   * @param (jQuery Object) target
+   * @return (jQuery Object) the appropriate parent
+   */
+   function parentWrapper(target) {
+    return target.parents('.portlet-body, #main-content').first();
+   }
+
+  /*
+   * Adds a loading class to the given element if 'loading' is not false and removes it if 'loading'
+   * is false.
+   * @param elem (jQuery Object)
+   * @param loadingStatus (Boolean)
+   */
+  function loading(elem, loadingStatus) {
+    if (loadingStatus !== false) {
+      loadingTimer = setTimeout(function() {
+        // if the wait is longer than the loading timeout we show a loading animation
+        elem.addClass('loading');
+      }, PureAdmin.LOADING_TIMEOUT);
+    } else {
+      clearTimeout(loadingTimer);
+      elem.removeClass('loading');
+    }
+  }
+})();

--- a/app/assets/stylesheets/pure_admin.css.scss
+++ b/app/assets/stylesheets/pure_admin.css.scss
@@ -6,6 +6,7 @@
 @import 'pure_admin/forms.css.scss';
 @import 'pure_admin/portlets.css.scss';
 @import 'pure_admin/tables.css.scss';
+@import 'pure_admin/table_filters.css.scss';
 @import 'pure_admin/flash_messages.css.scss';
 @import 'pure_admin/pagination.css.scss';
 @import 'pure_admin/buttons.css.scss';

--- a/app/assets/stylesheets/pure_admin/table_filters.css.scss
+++ b/app/assets/stylesheets/pure_admin/table_filters.css.scss
@@ -1,0 +1,90 @@
+#main-content,
+.portlet-body {
+  &:after {
+    content: '';
+    pointer-events: none;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    position: absolute;
+    opacity: 0;
+    display: block;
+
+    transition: opacity 200ms;
+
+    background-color: rgba(white, 0.75);
+
+    background-image: image-url('pending.gif');
+    background-position: center 5em;
+    background-repeat: no-repeat;
+    background-size: 4.5em;
+  }
+
+  &.loading {
+    position: relative;
+
+    &:after {
+      opacity: 1;
+    }
+  }
+}
+
+.table-filters {
+  border: 1px solid $grey-medium;
+  padding: 0.5rem;
+  position: relative;
+  width: auto;
+  display: block;
+
+  @media (min-width: 35.5em) {
+    padding-right: calc(50px + 0.5rem);
+    display: inline-block;
+  }
+
+  .filter-group {
+    display: block;
+
+    @media (min-width: 35.5em) {
+      margin-right: 1em;
+      float: left;
+    }
+
+    label {
+      text-transform: uppercase;
+      font-size: 0.9rem;
+      color: #999;
+    }
+
+    .filter-control {
+      height: 2.4em;
+    }
+
+    @media (min-width: 35.5em) {
+      .addon-wrapper {
+        display: block;
+
+        .input-addon,
+        .filter-control {
+          display: inline-block;
+          width: initial;
+        }
+
+        .input-addon {
+          line-height: 2.3em;
+        }
+      }
+    }
+  }
+
+  .filter-submit {
+    margin-right: 0;
+    margin-top: 0.5rem;
+
+    @media (min-width: 35.5em) {
+      position: absolute;
+      right: 0.5rem;
+      bottom: 0.5rem;
+    }
+  }
+}

--- a/app/helpers/pure_admin/table_filters_helper.rb
+++ b/app/helpers/pure_admin/table_filters_helper.rb
@@ -1,0 +1,155 @@
+##
+# Helper methods for table filters functionality.
+#
+# The recommended way of using this helper is
+#
+#   filters_for admin_members_path do |filter|
+#     filter.on :query                           the default is a text field
+#     filter.on :answer, options: %w(Yes No)     if given an options hash, a select will be used
+#     filter.on :status, as: :active_status      when given :active_status it will use the options
+#                                                  All, Active, and Inactive and the default of
+#                                                  Active. However these can be overridden by
+#                                                  :options and :default respectively.
+#     filter.on :starts_on, as: :date            when given :date, it will enable the pure_date
+#                                                  input type
+#  end
+module PureAdmin::TableFiltersHelper
+  ##
+  # Renders the table filters form to the view.
+  # @param path (String) the path for the form_tag
+  # @param options (Hash) all options that can be passed to form_tag are respected here.
+  # @yield The contents for the table filters
+  def table_filters(path, options = {}, &block)
+    options[:class] = merge_html_classes('pure-form pure-form-stacked table-filters clear-fix',
+      options[:class])
+
+    options[:remote] ||= true
+    options[:method] ||= :get
+
+    content = capture(&block)
+    content << content_tag(:div, submit_tag('Go', class: 'pure-button pure-button-primary'),
+      class: 'filter-group filter-submit')
+    content << hidden_field_tag(:sort, params[:sort])
+    content << hidden_field_tag(:reverse_order, params[:reverse_order])
+
+    form_tag path, options do
+      content
+    end
+  end
+
+  ##
+  # Renders a table filter item to the view.
+  # @param attribute (String, Symbol)
+  # @param options (Hash)
+  # @options options (Symbol) :type the type of field to display
+  # @options options (Hash) :options the select options for select inputs
+  # @options options (String) :default the default select option for select inputs
+  # @options options (Hash) :input_html any data contained within this hash will be passed to
+  #   the appropriate *_tag method
+  # @options options (Boolean, String) :label the text to display as a label if a string. If false,
+  #   this will prevent the label from being shown
+  # @options options (Hash) :label_html any data contained within this hash will be passed to
+  #   the content_tag builder for the label
+  # @yield The contents of the table filter with the label (unless options[:label] is false)
+  def table_filter_item(attribute, options = {}, &block)
+    if block_given?
+      field = capture(&block)
+    else
+      type = options.delete(:as) || :string
+
+      # If we're given an options array, we assume it to be a select filter.
+      # This allows for more concise code in the form
+      #   table_filter_item :status, options: %w(Yes No)
+      # or
+      #   filter.on :status, options %W(Yes No)
+      type = :select if options[:options].present?
+
+      # We define the :active_status type to shortcut a common filter type.
+      if type == :active_status
+        type = :select
+        options[:options] ||= %w(All Active Inactive)
+        options[:default] ||= 'Active'
+      end
+
+      input_html = options.delete(:input_html) || {}
+      input_html[:class] = merge_html_classes('filter-control', input_html[:class])
+
+      # Defaulting to a simple text field, we choose which field to output here.
+      # @note if at some point we wish to add a new field type, here is the place to add it
+      case type
+        when :select
+          options[:options] ||= []
+          field = select_tag(attribute,
+            options_for_select(options[:options], params[attribute.to_sym] || options[:default]),
+            input_html)
+        when :date
+          input_html[:class] = merge_html_classes('pure-admin-date', input_html[:class])
+          field = text_field_tag(attribute, params[attribute.to_sym], input_html)
+          icon = content_tag(:span, nil, class: 'input-addon fa fa-fw fa-calendar')
+          field = content_tag(:div, icon + field, class: 'addon-wrapper')
+        else # :string
+          field = text_field_tag(attribute, params[attribute.to_sym], input_html)
+      end
+    end
+
+    label = ''.html_safe
+    if options[:label] != false
+      label_html = options.delete(:label_html) || {}
+      label_text = options.delete(:label) || attribute.to_s.titleize
+      label = label_tag(attribute, label_text, label_html)
+    end
+
+    content_tag(:div, label + field, class: 'filter-group')
+  end
+
+  ##
+  # Renders a table filters section to the view using the table filter builder DSL.
+  # @param resource (ActiveRecord::Base) the model instance to build the table filters for.
+  # @param options (Hash) all options that can be passed to content_tag are respected here.
+  # @yield The contents of the table filters section
+  def filters_for(path, options = {}, &block)
+    builder = TableFiltersBuilder.new(self)
+    table_filters(path, options) do
+      capture(builder, &block)
+    end
+  end
+
+  ##
+  # Allows building of table filters using a custom DSL.
+  #
+  # <%= filters_for resources_path do |filter| %>
+  #   <%= filter.on :query %>
+  # <% end %>
+  class TableFiltersBuilder
+    ##
+    # Creates an instance of TableFiltersBuilder
+    # @param helper (ApplicationHelper) instance of application helper to allow access to view helpers.
+    # @yield instance of TableFiltersBuilder
+    def initialize(helper)
+      @helper = helper
+    end
+
+    ##
+    # Renders a table_filter_item inside the table_filters using a custom DSL.
+    #
+    # @param attribute (Symbol) the attribute on the resource
+    # @param options (Hash) all options that can be passed to content_tag are respected here.
+    # @yield The contents of the details panel item
+    def on(attribute, options = {}, &block)
+      if block_given?
+        helper.table_filter_item(attribute, options, &block)
+      else
+        helper.table_filter_item(attribute, options)
+      end
+    end
+
+    private
+
+      ##
+      # Access view helpers within the details panel builder
+      # @yield instance of ApplicationHelper
+      def helper
+        @helper
+      end
+  end
+end

--- a/spec/helpers/pure_admin/table_filters_helper_spec.rb
+++ b/spec/helpers/pure_admin/table_filters_helper_spec.rb
@@ -1,0 +1,181 @@
+require 'rails_helper'
+
+describe PureAdmin::TableFiltersHelper do
+  describe '#table_filters' do
+    context 'with a block' do
+      subject(:html) { helper.table_filters('http://t.t') { 'block content' } }
+
+      it 'renders a .table-filters form' do
+        expect(html).to have_selector('form.table-filters')
+      end
+
+      it 'sets the form action to the given path' do
+        expect(html).to have_selector('form.table-filters[action="http://t.t"]')
+      end
+
+      it 'sets the form method to get and remote to true' do
+        expect(html).to have_selector('form.table-filters[method="get"]')
+        expect(html).to have_selector('form.table-filters[data-remote="true"]')
+      end
+
+      it 'renders a submit button within the form' do
+        expect(html).to have_selector('form.table-filters .filter-submit input[type="submit"]')
+      end
+
+      it 'renders the hidden fields for sort order and reverse sort' do
+        expect(html).to have_selector('form.table-filters input[type="hidden"][name="sort"]')
+        expect(html).to have_selector('form.table-filters input[type="hidden"][name="reverse_order"]')
+      end
+
+      it 'renders the block within the .table-filters element' do
+        expect(html).to have_selector('form.table-filters', text: 'block content')
+      end
+
+      context 'specifically with options' do
+        subject(:html) { helper.table_filters('http://t.t', class: 'test') { 'block content' } }
+
+        it 'uses options as html attributes on the .table-filters form' do
+          expect(html).to have_selector('form.table-filters.test')
+        end
+
+        it 'renders the block within the .table-filters form' do
+          expect(html).to have_selector('form.table-filters.test', text: 'block content')
+        end
+      end
+    end
+  end
+
+  describe '#table-filter-item' do
+    subject(:html) { helper.table_filter_item(:query) }
+
+    it 'renders a .filter-group element' do
+      expect(html).to have_selector('.filter-group')
+    end
+
+    it 'renders a .filter-control text input element within .filter-group' do
+      expect(html).to have_selector('.filter-group input[type="text"][name="query"].filter-control')
+    end
+
+    it 'renders a label with the title as the titleized version of the attribute' do
+      expect(html).to have_selector('.filter-group label', text: 'Query')
+    end
+
+    context 'with options' do
+      context 'with options[:input_html]' do
+        it 'uses options as html attributes on the .filter-control input' do
+          html = helper.table_filter_item(:query, input_html: { class: 'test' })
+          expect(html).to have_selector('.filter-group input[type="text"][name="query"].filter-control.test')
+        end
+      end
+
+      context 'with options[:label_html]' do
+        it 'uses options as html attributes on the label' do
+          html = helper.table_filter_item(:query, label_html: { class: 'test' })
+          expect(html).to have_selector('.filter-group label.test')
+        end
+      end
+
+      context 'with options[:label] present' do
+        it 'uses this as the text for the label' do
+          html = helper.table_filter_item(:query, label: 'A Label')
+          expect(html).to have_selector('.filter-group label', text: 'A Label')
+        end
+
+        context 'when options[:label] == false' do
+          it 'does not render a label' do
+            html = helper.table_filter_item(:query, label: false)
+            expect(html).to_not have_selector('.filter-group label')
+          end
+        end
+      end
+
+      context 'with options[:type] == :select' do
+        subject(:html) { helper.table_filter_item(:query, as: :select) }
+
+        it 'renders a .filter-control select input' do
+          expect(html).to have_selector('.filter-group select.filter-control')
+        end
+
+        it 'has no options by default' do
+          expect(html).to_not have_selector('.filter-group select.filter-control option')
+        end
+
+        context 'when given options' do
+          it 'renders these options within the select.filter-control' do
+            html = helper.table_filter_item(:query, as: :select, options: %w(Yes No))
+            expect(html).to have_selector('.filter-group select.filter-control option', text: 'Yes')
+            expect(html).to have_selector('.filter-group select.filter-control option', text: 'No')
+          end
+        end
+
+        context 'when given a default' do
+          it 'uses this value to determine which option is selected by default' do
+            html = helper.table_filter_item(:query, as: :select, options: %w(Yes No), default: 'No')
+            expect(html).to have_selector('.filter-group select.filter-control option[selected]', text: 'No')
+          end
+        end
+      end
+
+      context 'with options[:type] == :date' do
+        subject(:html) { helper.table_filter_item(:query, as: :date) }
+        it 'renders a .filter-control date input element within .filter-group' do
+          selector = '.filter-group input[type="text"][name="query"].filter-control.pure-admin-date'
+          expect(html).to have_selector(selector)
+        end
+
+        it 'renders a calendar icon addon within .addon-wrapper' do
+          expect(html).to have_selector('.filter-group .addon-wrapper span.input-addon.fa-calendar')
+        end
+      end
+
+      context 'with options[:type] == :active_status' do
+        subject(:html) { helper.table_filter_item(:query, as: :active_status) }
+
+        it 'renders a .filter-control select input' do
+          expect(html).to have_selector('.filter-group select.filter-control')
+        end
+
+        it 'renders All, Active, Inactive options' do
+          expect(html).to have_selector('.filter-group select.filter-control option', text: 'All')
+          expect(html).to have_selector('.filter-group select.filter-control option', text: 'Active')
+          expect(html).to have_selector('.filter-group select.filter-control option', text: 'Inactive')
+        end
+
+        it 'sets Active as the default' do
+          expect(html).to have_selector('.filter-group select.filter-control option[selected]',
+            text: 'Active')
+        end
+      end
+
+      context 'with options[:type] as anything else' do
+        it 'renders a text field' do
+          html = helper.table_filter_item(:query, as: :something_else)
+          expect(html).to have_selector('.filter-group input[type="text"][name="query"].filter-control')
+        end
+      end
+
+      context 'when options[:options] is present' do
+        it 'renders a select field regardless of the type given' do
+          html = helper.table_filter_item(:query, as: :something_else, options: %w(Yes No))
+          expect(html).to have_selector('.filter-group select.filter-control')
+        end
+      end
+    end
+
+    context 'with a block' do
+      subject(:html) { helper.table_filter_item(:query) { 'block content' } }
+
+      it 'renders a .filter-group element' do
+        expect(html).to have_selector('.filter-group')
+      end
+
+      it 'renders the block within the .filter-group element' do
+        expect(html).to have_selector('.filter-group', text: 'block content')
+      end
+
+      it 'renders a label with the title as the titleized version of the attribute' do
+        expect(html).to have_selector('.filter-group label', text: 'Query')
+      end
+    end
+  end
+end


### PR DESCRIPTION
We only had one loading timer so when a page is loaded
with a bunch of portlets set to expand by default, this
was getting overridden each time.
