### PR TITLE
Form input improvements

### DIFF
--- a/app/assets/javascripts/pure_admin/inputs/select.js
+++ b/app/assets/javascripts/pure_admin/inputs/select.js
@@ -16,6 +16,6 @@ PureAdmin.inputs.select = {
   },
 
   formatResult: function(result) {
-    return result.name || result.text || '<span class="text-muted">(blank)</span>'
+    return result.name || result.text || '<span class="text-muted">(blank)</span>';
   }
 };

--- a/app/inputs/addon_input.rb
+++ b/app/inputs/addon_input.rb
@@ -5,7 +5,7 @@ class AddonInput < SimpleForm::Inputs::StringInput
 
   def icon
     if options[:icon].present?
-      content_tag(:span, nil, class: ['input-addon', 'fa', 'fa-fw', options[:icon]])
+      template.content_tag(:span, nil, class: ['input-addon', 'fa', 'fa-fw', options[:icon]])
     else
       ''
     end

--- a/app/inputs/collection_select_input.rb
+++ b/app/inputs/collection_select_input.rb
@@ -8,7 +8,10 @@ class CollectionSelectInput < SimpleForm::Inputs::CollectionSelectInput
 
   def input_html_options
     super.deep_merge(
-      style: 'width: 100%;'
+      style: 'width: 100%;',
+      data: {
+        tags: options[:create_when_no_match] || false
+      }
     )
   end
 end

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -127,7 +127,8 @@ SimpleForm.setup do |config|
 
   # Custom wrappers for input types. This should be a hash containing an input
   # type as key and the wrapper that will be used for all inputs with specified type.
-  config.wrapper_mappings = { addon: :addon, email: :addon, tel: :addon }
+  config.wrapper_mappings = { addon: :addon, email: :addon, tel: :addon, pure_date: :addon,
+    pure_time: :addon, pure_datetime: :addon, autocomplete: :addon }
 
   # Default priority for time_zone inputs.
   # config.time_zone_priority = nil


### PR DESCRIPTION
This commit makes the following improvements to forms and inputs:
- the addon wrapper is chosen automatically for pure_date, pure_time, pure_datetime, and autocomplete inputs
- the selection input allows for select2's tags feature with the create_when_no_match option
- use template.content_tag in the addon input
- fix javascript syntax issue in select.js
