### PR TITLE
Add boolean_label method

### DIFF
--- a/app/helpers/pure_admin/application_helper.rb
+++ b/app/helpers/pure_admin/application_helper.rb
@@ -9,4 +9,19 @@ module PureAdmin::ApplicationHelper
   def merge_html_classes(value1, value2)
     [value1, value2].flatten.compact
   end
+
+  ##
+  # Provides a "nice" looking boolean display using tags.
+  # @param (Boolean) value
+  # @return (String) HTML
+  def boolean_label(value)
+    return value if value.nil?
+
+    icon_class = 'fa'
+    icon_class << (value ? ' fa-check' : ' fa-times')
+    tag_class = 'tag'
+    tag_class << ' tag-green' if value
+
+    content_tag :span, content_tag(:i, '', class: icon_class), class: tag_class
+  end
 end

--- a/spec/helpers/pure_admin/application_helper_spec.rb
+++ b/spec/helpers/pure_admin/application_helper_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe PureAdmin::ApplicationHelper do
+  pending '#merge_html_classes'
+
+  describe '#boolean_label' do
+    context 'when the value is nil' do
+      it 'returns nil' do
+        expect(helper.boolean_label(nil)).to be_nil
+      end
+    end
+
+    context 'when the value is "truthy"' do
+      let(:html) { helper.boolean_label(true) }
+
+      it 'returns HTML for a tag class' do
+        expect(html).to have_selector('.tag.tag-green')
+      end
+      it 'returns HTML for a check icon' do
+        expect(html).to have_selector('.fa.fa-check')
+      end
+    end
+
+    context 'when the value is not "truthy"' do
+      let(:html) { helper.boolean_label(false) }
+
+      it 'returns HTML for a tag class' do
+        expect(html).to have_selector('.tag')
+      end
+      it 'returns HTML for a cross icon' do
+        expect(html).to have_selector('.fa.fa-times')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a helper method, `boolean_label`.
It uses the tags defined in tags.scss.css to output appropriate HTML.
