### PR TITLE
Allow multiple portlets to be loaded at once

### DIFF
--- a/app/assets/javascripts/pure_admin/portlets.js
+++ b/app/assets/javascripts/pure_admin/portlets.js
@@ -1,6 +1,9 @@
 var PureAdmin = PureAdmin || {};
 
 PureAdmin.portlets = {
+
+  loadingTimer: {},
+
   /*
    * Toggles the 'expanded' class for the clicked portlet if it is closable.
    * Additionally calls the loadPortlet function if the portlet is now expanded.
@@ -51,7 +54,7 @@ PureAdmin.portlets = {
       return;
     }
 
-    PureAdmin.portlets.loading(portlet, true);
+    PureAdmin.portlets.loading(portlet, true, source);
 
     $.ajax(source, {
       success: function(data, textStatus, jqXHR) {
@@ -62,7 +65,7 @@ PureAdmin.portlets = {
       },
       complete: function(jxXHR, textStatus) {
         portlet.data('body-loaded', true);
-        PureAdmin.portlets.loading(portlet, false);
+        PureAdmin.portlets.loading(portlet, false, source);
       }
     });
   },
@@ -73,14 +76,15 @@ PureAdmin.portlets = {
    * @param elem (jQuery Object)
    * @param loading (Boolean)
    */
-  loading: function(elem, loading) {
+  loading: function(elem, loading, uniqueId) {
     if (loading !== false) {
-      PureAdmin.portlets.loadingTimer = setTimeout(function() {
+      PureAdmin.portlets.loadingTimer[uniqueId] = setTimeout(function() {
         // if the wait is longer than the loading timeout we show a loading animation
         elem.addClass('loading');
       }, PureAdmin.LOADING_TIMEOUT);
     } else {
-      clearTimeout(PureAdmin.portlets.loadingTimer);
+      clearTimeout(PureAdmin.portlets.loadingTimer[uniqueId]);
+      delete PureAdmin.portlets.loadingTimer[uniqueId];
       elem.removeClass('loading');
     }
   },


### PR DESCRIPTION
This commit fixes a bug that showed itself when multiple
portlets are set to load at once.

The logic that controlled the loading indicator only
expected one timeout with a specific name at once, and was
clearing timeouts early and holding onto others indefinitely.
