### PR TITLE
Define button-group display class

### DIFF
--- a/app/assets/stylesheets/pure_admin/buttons.css.scss
+++ b/app/assets/stylesheets/pure_admin/buttons.css.scss
@@ -46,3 +46,15 @@
     margin: 0;
   }
 }
+
+.button-group {
+  white-space: nowrap;
+
+  .pure-button {
+    margin-right: -0.3em;
+
+    &.pure-button:not(:first-of-type) {
+      border-left: 0;
+    }
+  }
+}


### PR DESCRIPTION
This commit adds the .button-group wrapper class which allows for a group of buttons to be displayed directly next to each other.

![screen shot 2016-07-21 at 11 11 48](https://cloud.githubusercontent.com/assets/5688326/17008804/f90b4b68-4f33-11e6-83e5-3eb6847038f1.png)

Example:

```
<div class="button-group">
  <%= link_to 'Edit', edit_object_path(@object), class: 'pure-button button-small' %>
  <%= link_to 'Show', object_path(@object), class: 'pure-button button-small' %>    
  <%= link_to 'Delete', object_path(@object, method: :delete), class: 'pure-button button-small' %>    
</div>
```
