### PR TITLE
Respect symbols properly for portlet icon

### DIFF
--- a/app/assets/stylesheets/pure_admin/portlets.css.scss
+++ b/app/assets/stylesheets/pure_admin/portlets.css.scss
@@ -86,7 +86,7 @@ $icon-minus: '\f068';
   }
 }
 
-.portlet-heading-icon {
+.portlet-heading-icon.fa {
   line-height: $base-font-size * 1.5;
   border-right: 1px solid $grey-medium-dark;
   padding: 0 $base-font-size * 0.8;

--- a/app/helpers/pure_admin/portlet_helper.rb
+++ b/app/helpers/pure_admin/portlet_helper.rb
@@ -21,7 +21,9 @@ module PureAdmin::PortletHelper
     body_html = options.delete(:body_html) || {}
     body_html[:class] = merge_html_classes('portlet-body clear-fix', body_html[:class])
 
-    icon = content_tag(:i, nil, class: "portlet-heading-icon fa fa-fw fa-#{options[:icon]}") if options[:icon]
+    if options[:icon]
+      icon = content_tag(:i, nil, class: "portlet-heading-icon fa fa-fw fa-#{options[:icon].to_s.dasherize}")
+    end
 
     # This determines if the portlet can be closed. If it is remote it can be closed. If not,
     # it is determined by the presence of expand in the options.


### PR DESCRIPTION
This commit also ensures that the portlet icon has the correct specificity.
