### PR TITLE
Correct styling for details panels within a form

### DIFF
--- a/app/assets/stylesheets/pure_admin/forms.css.scss
+++ b/app/assets/stylesheets/pure_admin/forms.css.scss
@@ -105,6 +105,11 @@
   .pure-form-indented {
     @include pure-form-indented;
   }
+
+  .details-panel-item label {
+    float: none;
+    color: inherit;
+  }
 }
 
 .editor-field {


### PR DESCRIPTION
Current behaviour misplaces the label when a details panel is placed within a form. A common use-case for this is adding created/updated information within a form partial.
