### PR TITLE
Add portlet controls capability

### DIFF
--- a/app/assets/javascripts/pure_admin/portlets.js
+++ b/app/assets/javascripts/pure_admin/portlets.js
@@ -78,10 +78,12 @@ PureAdmin.portlets = {
    */
   loading: function(elem, loading, uniqueId) {
     if (loading !== false) {
-      PureAdmin.portlets.loadingTimer[uniqueId] = setTimeout(function() {
-        // if the wait is longer than the loading timeout we show a loading animation
-        elem.addClass('loading');
-      }, PureAdmin.LOADING_TIMEOUT);
+      if (!PureAdmin.portlets.loadingTimer[uniqueId]) {
+        PureAdmin.portlets.loadingTimer[uniqueId] = setTimeout(function() {
+          // if the wait is longer than the loading timeout we show a loading animation
+          elem.addClass('loading');
+        }, PureAdmin.LOADING_TIMEOUT);
+      }
     } else {
       clearTimeout(PureAdmin.portlets.loadingTimer[uniqueId]);
       delete PureAdmin.portlets.loadingTimer[uniqueId];
@@ -101,6 +103,15 @@ PureAdmin.portlets = {
       (thrown || 'Error') + '" loading content</p>');
   },
 
+  /*
+   * Load portlets that have a data-expand attribute
+   */
+  autoExpand: function() {
+    $('.portlet[data-expand]').each(function() {
+      PureAdmin.portlets.loadPortlet($(this));
+    });
+  },
+
   ready: function() {
     // Automatically open portlets that match the anchor
     var anchorValue = document.location.toString().split("#")[1];
@@ -110,9 +121,7 @@ PureAdmin.portlets = {
     }
 
     // Automatically open portlets that have the data-expand attribute set
-    $('.portlet[data-expand]').each(function() {
-      PureAdmin.portlets.loadPortlet($(this));
-    });
+    PureAdmin.portlets.autoExpand();
   }
 };
 
@@ -121,6 +130,10 @@ PureAdmin.portlets = {
  */
 $(document).on('click', '.portlet-heading', PureAdmin.portlets.toggle);
 
-
 $(document).ready(PureAdmin.portlets.ready);
 $(document).on('turbolinks:load', PureAdmin.portlets.ready);
+
+$(document).ajaxSuccess(function() {
+  // Automatically open portlets that have the data-expand attribute set
+  PureAdmin.portlets.autoExpand();
+});

--- a/app/assets/stylesheets/pure_admin/portlets.css.scss
+++ b/app/assets/stylesheets/pure_admin/portlets.css.scss
@@ -98,11 +98,33 @@ $icon-minus: '\f068';
   line-height: $base-font-size * 1.5;
   border-left: 1px solid $grey-medium-dark;
   padding: 0 $base-font-size * 0.8;
+  padding-right: 0;
   display: table-cell;
   vertical-align: middle;
+  white-space: nowrap;
+
+  .portlet-control-item {
+    display: inline-block;
+    margin-right: $base-font-size * 0.8;
+
+    .pure-button,
+    .pure-menu-link {
+      font-size: 0.75rem;
+    }
+
+    .dropdown {
+      float: none;
+    }
+
+    .pure-menu-has-children {
+      display: block;
+    }
+  }
 }
 
 .portlet-indicator {
+  padding-right: $base-font-size * 0.8;
+
   &:hover {
     cursor: pointer;
   }

--- a/app/helpers/pure_admin/portlet_helper.rb
+++ b/app/helpers/pure_admin/portlet_helper.rb
@@ -11,7 +11,7 @@ module PureAdmin::PortletHelper
   # @yield The contents of the portlet
   def portlet(title, options = {}, &block)
     portlet_html = options[:portlet_html] || {}
-    portlet_html[:class] = ['portlet', portlet_html[:class]]
+    portlet_html[:class] = ['portlet clear-fix', portlet_html[:class]]
     portlet_html[:data] ||= {}
     portlet_html[:data][:source] = options[:source] unless block_given?
 
@@ -32,10 +32,24 @@ module PureAdmin::PortletHelper
 
     portlet_html[:data][:closable] = closable
 
-    if closable
-      controls_content = content_tag(:div, class: 'portlet-controls') do
-        content_tag(:span, nil, class: 'portlet-indicator')
+    controls_content = ''.html_safe
+    controls = options.delete(:controls)
+    if controls.present?
+      if controls.respond_to?(:each)
+        controls.each do |control|
+          controls_content << content_tag(:span, control, class: 'portlet-control-item')
+        end
+      else
+        controls_content << content_tag(:span, controls, class: 'portlet-control-item')
       end
+    end
+
+    if closable
+      controls_content << content_tag(:span, nil, class: 'portlet-indicator')
+    end
+
+    if controls_content.present?
+      controls_wrapper = content_tag(:div, controls_content, class: 'portlet-controls')
     end
 
     # This determines if the portlet should be expanded by default. If it is explicitly given that
@@ -49,7 +63,7 @@ module PureAdmin::PortletHelper
     end
 
     heading_content = content_tag(:div, heading_html) do
-      ( icon || ''.html_safe ) + content_tag(:h4, title) + ( controls_content || ''.html_safe )
+      (icon || ''.html_safe) + content_tag(:h4, title) + (controls_wrapper || ''.html_safe)
     end
 
     body_content = content_tag(:div, (capture(&block) if block_given?), body_html)

--- a/spec/helpers/pure_admin/portlet_helper_spec.rb
+++ b/spec/helpers/pure_admin/portlet_helper_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 describe PureAdmin::PortletHelper do
   describe '#portlet' do
     context 'when a block is given' do
-      subject(:html) { helper.portlet('apples', portlet_html: { class: 'classy', data: { whizz: 'pop' } }) { 'banana' } }
+      subject(:html) {
+        helper.portlet('apples', portlet_html: { class: 'classy', data: { whizz: 'pop' } }) { 'banana' }
+      }
 
       it 'uses options as html attributes' do
         expect(html).to have_selector('div.portlet[data-whizz="pop"]')
@@ -106,6 +108,26 @@ describe PureAdmin::PortletHelper do
       it 'adds other attributes (ie: data)' do
         expect(helper.portlet('Peaches', body_html: { data: { pits: true } })).to \
           have_selector('.portlet-body[data-pits]')
+      end
+    end
+
+    context 'when controls are passed in' do
+      context 'when a single control is passed' do
+        it 'includes the controls within the .portlet-controls class' do
+          expect(helper.portlet('Pineapple', controls: link_to('Test', 'http://test.test'))).to \
+            have_selector('.portlet-heading .portlet-controls .portlet-control-item', text: 'Test')
+        end
+      end
+
+      context 'when an array of controls are passed' do
+        it 'includes each controls within the .portlet-controls class' do
+          controls = [link_to('Test', 'http://test.test'), link_to('Spec', 'http://spec.spec')]
+          html = helper.portlet('Pineapple', controls: controls);
+          expect(html).to have_selector('.portlet-heading .portlet-controls .portlet-control-item',
+            text: 'Test')
+          expect(html).to have_selector('.portlet-heading .portlet-controls .portlet-control-item',
+            text: 'Test')
+        end
       end
     end
   end


### PR DESCRIPTION
This commit adds the ability for controls to be added to portlets.
They appear on the right side of the portlet window to the left of the expansion indicator and can be instantiated like so:

``` erb
<%= portlet 'Details', controls: [link_to 'test'] do ...%>
```

It also fixes an issue resulting from portlets being auto-loaded.
