### PR TITLE
Make all javascript turbo links compatible

### DIFF
--- a/app/assets/javascripts/pure_admin/inputs.js
+++ b/app/assets/javascripts/pure_admin/inputs.js
@@ -18,3 +18,7 @@ $(document).ready(function(context) {
 $(document).on('ajaxSuccess', function(context) {
   PureAdmin.inputs.initAll(context);
 });
+
+$(document).on('turbolinks:load', function(context) {
+  PureAdmin.inputs.initAll(context);
+});

--- a/app/assets/javascripts/pure_admin/main_header.js
+++ b/app/assets/javascripts/pure_admin/main_header.js
@@ -1,14 +1,21 @@
-$('document').ready(function() {
-  $('#wrap').waypoint(function(direction) {
-    $('#back-to-top').toggle(direction === 'down');
-  }, { offset: -300 });
+var PureAdmin = PureAdmin || {};
 
-  $('#wrap').waypoint(function(direction) {
-    $('#wrap').toggleClass('no-header', direction === 'down');
-  }, { offset: -48 });
+PureAdmin.header = {
+  ready: function() {
+    $('#wrap').waypoint(function(direction) {
+      $('#back-to-top').toggle(direction === 'down');
+    }, { offset: -300 });
 
-  $('#back-to-top').on('click', $.debounce(1000, true, function() {
-    $("html, body").animate({ scrollTop: 0 }, 300);
-    $('#wrap').removeClass('no-header');
-  }));
-});
+    $('#wrap').waypoint(function(direction) {
+      $('#wrap').toggleClass('no-header', direction === 'down');
+    }, { offset: -48 });
+
+    $('#back-to-top').on('click', $.debounce(1000, true, function() {
+      $("html, body").animate({ scrollTop: 0 }, 300);
+      $('#wrap').removeClass('no-header');
+    }));
+  }
+};
+
+$(document).ready(PureAdmin.header.ready)
+$(document).on('turbolinks:load', PureAdmin.header.ready)

--- a/app/assets/javascripts/pure_admin/main_menu.js
+++ b/app/assets/javascripts/pure_admin/main_menu.js
@@ -72,34 +72,37 @@ PureAdmin.mainMenu = {
     subMenu.addClass('hidden').find('.pure-menu').html($('#main-menu .current > .sub-menu').clone());
     mainMenu.removeClass('navigating').find('.pure-menu-item').removeClass('menu-active');
     mainMenu.find('.pure-menu-link').off('click', PureAdmin.mainMenu.closeSubMenu);
+  },
+
+  ready: function() {
+    PureAdmin.mainMenu.updateArrows($('#main-menu'));
+
+    $('*[rel=main-menu-scroll]').on('click', function(event) {
+      PureAdmin.mainMenu.scroll($('#main-menu'));
+    });
+
+    $('*[rel=sub-menu-scroll]').on('click', function(event) {
+      PureAdmin.mainMenu.scroll($('#sub-menu'));
+    });
+
+    $('#main-menu nav').on('scroll', function(event) {
+      PureAdmin.mainMenu.updateArrows($('#main-menu'));
+    });
+
+    $('#sub-menu nav').on('scroll', function(event) {
+      PureAdmin.mainMenu.updateArrows($('#sub-menu'));
+    });
+
+    $('#main-menu .pure-menu-link').on('click', function(event) {
+      var element = $(event.target).closest('li');
+      PureAdmin.mainMenu.openSubMenu(element);
+    });
+
+    $('#main').on('click', function(event) {
+      PureAdmin.mainMenu.closeSubMenu();
+    });
   }
 };
 
-$('document').ready(function() {
-  PureAdmin.mainMenu.updateArrows($('#main-menu'));
-
-  $('*[rel=main-menu-scroll]').on('click', function(event) {
-    PureAdmin.mainMenu.scroll($('#main-menu'));
-  });
-
-  $('*[rel=sub-menu-scroll]').on('click', function(event) {
-    PureAdmin.mainMenu.scroll($('#sub-menu'));
-  });
-
-  $('#main-menu nav').on('scroll', function(event) {
-    PureAdmin.mainMenu.updateArrows($('#main-menu'));
-  });
-
-  $('#sub-menu nav').on('scroll', function(event) {
-    PureAdmin.mainMenu.updateArrows($('#sub-menu'));
-  });
-
-  $('#main-menu .pure-menu-link').on('click', function(event) {
-    var element = $(event.target).closest('li');
-    PureAdmin.mainMenu.openSubMenu(element);
-  });
-
-  $('#main').on('click', function(event) {
-    PureAdmin.mainMenu.closeSubMenu();
-  });
-});
+$(document).ready(PureAdmin.mainMenu.ready)
+$(document).on('turbolinks:load', PureAdmin.mainMenu.ready)

--- a/app/assets/javascripts/pure_admin/modals.js
+++ b/app/assets/javascripts/pure_admin/modals.js
@@ -191,3 +191,7 @@ PureAdmin.modals = {
 $('document').ready(function() {
   $('*[modal]:not(.bound-modal)').addClass('bound-modal').on('click', PureAdmin.modals.show);
 });
+
+$(document).on('turbolinks:load', function() {
+  $('*[modal]:not(.bound-modal)').addClass('bound-modal').on('click', PureAdmin.modals.show);
+})

--- a/app/assets/javascripts/pure_admin/portlets.js
+++ b/app/assets/javascripts/pure_admin/portlets.js
@@ -99,6 +99,20 @@ PureAdmin.portlets = {
     PureAdmin.flash_messages.create('error', 'An error occured when loading the remote URL.');
     return $('<p class="text-error text-center"><i class="fa fa-exclamation-triangle"></i> "' +
       (thrown || 'Error') + '" loading content</p>');
+  },
+
+  ready: function() {
+    // Automatically open portlets that match the anchor
+    var anchorValue = document.location.toString().split("#")[1];
+    if (typeof anchorValue !== 'undefined' && anchorValue.length !== 0) {
+      var anchorPortlet = $('.portlet.' + anchorValue);
+      PureAdmin.portlets.loadPortlet(anchorPortlet);
+    }
+
+    // Automatically open portlets that have the data-expand attribute set
+    $('.portlet[data-expand]').each(function() {
+      PureAdmin.portlets.loadPortlet($(this));
+    });
   }
 };
 
@@ -107,16 +121,6 @@ PureAdmin.portlets = {
  */
 $(document).on('click', '.portlet-heading', PureAdmin.portlets.toggle);
 
-$(document).ready(function() {
-  // Automatically open portlets that match the anchor
-  var anchorValue = document.location.toString().split("#")[1];
-  if (typeof anchorValue !== 'undefined' && anchorValue.length !== 0) {
-    var anchorPortlet = $('.portlet.' + anchorValue);
-    PureAdmin.portlets.loadPortlet(anchorPortlet);
-  }
 
-  // Automatically open portlets that have the data-expand attribute set
-  $('.portlet[data-expand]').each(function() {
-    PureAdmin.portlets.loadPortlet($(this));
-  });
-});
+$(document).ready(PureAdmin.portlets.ready);
+$(document).on('turbolinks:load', PureAdmin.portlets.ready);


### PR DESCRIPTION
We use `$(document).ready({...});` heavily so added `turbolinks:load` to keep this compatability but work with turbolinks.
