### PR TITLE
Initialise modal triggers within ajax-loaded elements

### DIFF
--- a/app/assets/javascripts/pure_admin/modals.js
+++ b/app/assets/javascripts/pure_admin/modals.js
@@ -1,6 +1,10 @@
 var PureAdmin = PureAdmin || {};
 
 PureAdmin.modals = {
+  init: function () {
+    $('*[modal]:not(.bound-modal)').addClass('bound-modal').on('click', PureAdmin.modals.show);
+  },
+
   show: function (event) {
     event.preventDefault();
 
@@ -189,9 +193,13 @@ PureAdmin.modals = {
 };
 
 $('document').ready(function() {
-  $('*[modal]:not(.bound-modal)').addClass('bound-modal').on('click', PureAdmin.modals.show);
+  PureAdmin.modals.init();
 });
 
 $(document).on('turbolinks:load', function() {
-  $('*[modal]:not(.bound-modal)').addClass('bound-modal').on('click', PureAdmin.modals.show);
-})
+  PureAdmin.modals.init();
+});
+
+$(document).on('ajaxSuccess', function() {
+  PureAdmin.modals.init();
+});


### PR DESCRIPTION
This commit adds functionality to initialise the modal triggers when the trigger itself is loaded via ajax.

A real-world example is a delete link (using the confirm modal) within a remote portlet.

NOTE: This functionality is also provided in the "Improvements to modal handling" PR (https://github.com/blaknite/pure-admin-rails/pull/23)
