### PR TITLE
Add a partial refresh capability

### DIFF
--- a/app/assets/javascripts/pure_admin/partial_refresh.js
+++ b/app/assets/javascripts/pure_admin/partial_refresh.js
@@ -1,0 +1,82 @@
+var PureAdmin = PureAdmin || {};
+
+PureAdmin.partial_refresh = {
+  loadingTimer: {},
+
+  init: function() {
+    var matchElem = '.js-partial-refresh';
+
+    /*
+    * When the ajaxSend event is triggered on matchElem, show the loading indicator.
+    */
+    $(document).on('ajax:beforeSend', matchElem, function(e, data) {
+      var target = $(e.currentTarget);
+      var uniqueId = Math.floor((Math.random() * 1000) + 1);
+
+      target.data('pure-admin-unique-id', uniqueId);
+      loading(parentWrapper(target), true, uniqueId);
+      e.stopPropagation();
+    });
+
+    /*
+    * When the ajaxSuccess event is triggered on matchElem, replace the contents.
+    */
+    $(document).on('ajax:success', matchElem, function(e, data) {
+      var target = $(e.currentTarget);
+      var uniqueId = target.data('pure-admin-unique-id');
+      var wrapper = parentWrapper(target);
+
+      wrapper.html(data);
+      loading(wrapper, false, uniqueId);
+      e.stopPropagation();
+    });
+
+    /*
+    * When the ajaxError event is triggered on matchElem, show a flash message.
+    */
+    $(document).on('ajax:error', matchElem, function(e, xhr, status, thrown) {
+      var target = $(e.currentTarget);
+
+      PureAdmin.flashMessages.create('error', thrown || 'Error');
+      loading(parentWrapper(target), false, target.data('pure-admin-unique-id'));
+      e.stopPropagation();
+    });
+
+    /*
+    * Return the appropriate parent of the target element.
+    * If the element has a data-parent attribute, return the matching jQuery object.
+    * Otherwise, return the portlet or main-content div elements, whichever comes first.
+    * @param (jQuery Object) target
+    * @return (jQuery Object) the appropriate parent
+    */
+    function parentWrapper(target) {
+      if (target.data('parent')) {
+        return $(target.data('parent'));
+      } else {
+        return target.parents('.portlet-body, #main-content').first();
+      }
+    }
+
+    /*
+    * Adds a loading class to the given element if 'loading' is not false and removes it if 'loading'
+    * is false.
+    * @param elem (jQuery Object)
+    * @param loadingStatus (Boolean)
+    */
+    function loading(elem, loadingStatus, uniqueId) {
+      if (loadingStatus !== false) {
+        PureAdmin.partial_refresh.loadingTimer[uniqueId] = setTimeout(function() {
+          // if the wait is longer than the loading timeout we show a loading animation
+          elem.addClass('loading');
+        }, PureAdmin.LOADING_TIMEOUT);
+      } else {
+        clearTimeout(PureAdmin.partial_refresh.loadingTimer[uniqueId]);
+        delete PureAdmin.partial_refresh.loadingTimer[uniqueId];
+        elem.removeClass('loading');
+      }
+    }
+  }
+};
+
+$(document).ready(PureAdmin.partial_refresh.init);
+$(document).on('turbolinks:load', PureAdmin.partial_refresh.init);


### PR DESCRIPTION
This commit adds the notion of a partial refresh.

A partial refresh is one that is tied to an ajax request, and partially replaces the content on the page.

For example, let’s say you have pagination set up with `remote: true`, meaning the request will be made via ajax. If you add the `js-partial-refresh` class to the pagination element, the new behaviour will be to show a loading indicator, replace the parent’s content with the returned data, then remove the loading indicator.

The parent wrapper can be defined by a `data-parent` attribute on the `js-partial-refresh` element, or it will be the closest `.portlet` or `#main-content`.
