### PR TITLE
Rails 5.1 UJS compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * DSL for details panels
 * DSL for portlets
 * Partial refresh for tables
+* Partial refresh support for Rails 5.1
 * Replace crummy with crumpet (https://github.com/blaknite/crumpet)
 
 ## 1.4.1

--- a/app/assets/javascripts/pure_admin/partial_refresh.js
+++ b/app/assets/javascripts/pure_admin/partial_refresh.js
@@ -29,7 +29,9 @@ PureAdmin.partial_refresh = {
       var uniqueId = target.data('pure-admin-unique-id');
       var wrapper = parentWrapper(target);
 
-      wrapper.html(data);
+      // Data will be undefined if we are using Rails 5.1 since UJS dropped
+      // jQuery, so we get the data from the Event
+      wrapper.html(data || e.detail[2].response);
       loading(wrapper, false, uniqueId);
       e.stopPropagation();
     });


### PR DESCRIPTION
UJS in Rails 5.1 has dropped jQuery as a dependency so we need to use the event
object itself. I have left the usual data variable in there for backwards compatibility.