### PR TITLE
Make links in portlet headings clickable

### DIFF
--- a/app/assets/javascripts/pure_admin/portlets.js
+++ b/app/assets/javascripts/pure_admin/portlets.js
@@ -122,6 +122,11 @@ PureAdmin.portlets = {
 
     // Automatically open portlets that have the data-expand attribute set
     PureAdmin.portlets.autoExpand();
+
+    // Stop links from being overriden by portlets onclick handler
+    $(".portlet-heading a").click(function(e) {
+      e.stopPropagation();
+    });
   }
 };
 


### PR DESCRIPTION
The `onClick()` that controls the expanding/collapsing of portlets was hijacking links supplied in the controls.