### PR TITLE
Update README to include simple_form as requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ gem 'crummy', github: 'blaknite/crummy', branch: 'master'
 gem 'font-awesome-rails'
 gem 'select2-rails'
 gem 'pure-css-rails'
+gem 'simple_form'
 ```
 
 Run


### PR DESCRIPTION
Simple Form is used in initializers which are auto loaded when running generators or anything else. Either we decide Simple Form is a requirement or make the initializers detect if gem is installed.